### PR TITLE
Meta function to retrieve post meta

### DIFF
--- a/lib/posts.js
+++ b/lib/posts.js
@@ -129,6 +129,22 @@ PostsRequest.prototype.id = function( id ) {
 };
 
 /**
+ * Retrieve Post Meta
+ *
+ * @method meta
+ * @chainable
+ * @param {Number} metaId Id of the meta property to retrieve if Null retrieve all
+ * @return {PostsRequest} The PostsRequest instance (for chainin)
+ */
+PostsRequest.prototype.meta = function( metaId ) {
+	this._path.action = 'meta';
+	this._supportedMethods = [ 'get', 'post' ];
+	this._path.actionId = metaId || null;
+
+	return this;
+};
+
+/**
  * Specify that we are getting the comments for a specific post
  *
  * @method comments

--- a/tests/lib/posts.js
+++ b/tests/lib/posts.js
@@ -92,6 +92,22 @@ describe( 'wp.posts', function() {
 			expect( posts._path.id ).to.equal( 314159 );
 		});
 
+		it( 'provides a method to get all meta for given post', function() {
+			expect( posts).to.have.property( 'meta' );
+			expect( posts.meta).to.be.a( 'function' );
+			posts.id( 3 ).meta();
+			expect( posts._path ).to.have.property( 'action' );
+			expect( posts._path.action ).to.equal( 'meta' );
+		});
+
+		it( 'provides a method to get specific post meta', function() {
+			expect( posts).to.have.property( 'meta' );
+			expect( posts.meta).to.be.a( 'function' );
+			posts.id( 3 ).meta( 5 );
+			expect( posts._path ).to.have.property( 'actionId' );
+			expect( posts._path.actionId ).to.equal( 5 );
+		});
+
 		it( 'parses ID parameters into integers', function() {
 			expect( posts ).to.have.property( 'id' );
 			expect( posts.id ).to.be.a( 'function' );


### PR DESCRIPTION
Added a chainable function for getting post meta. Can be called after the .id() method. 

