### PR TITLE
Add .version and .namespace methods to wp-request

### DIFF
--- a/lib/shared/wp-request.js
+++ b/lib/shared/wp-request.js
@@ -293,7 +293,14 @@ WPRequest.prototype._checkMethodSupport = function( method ) {
  * @return {String} The rendered path
  */
 WPRequest.prototype._renderPath = function() {
-	var path = new Route( this._template );
+	// Combine all parts of the path together, filtered to omit any components
+	// that are unspecified or empty strings, to create the full path template
+	var template = [
+		this._namespace,
+		this._version,
+		this._template
+	].filter( identity ).join( '/' );
+	var path = new Route( template );
 	var pathValues = validatePath( this._path, this._pathValidators );
 
 	return path.reverse( pathValues ) || '';
@@ -353,6 +360,36 @@ WPRequest.prototype._auth = function( request, forceAuthentication ) {
 
 // Chaining methods
 // ================
+
+/**
+ * Set the namespace of the request, e.g. to specify the API root for routes
+ * registered by wp core ("wp") or by any given plugin. Any previously-set
+ * namespace will be overwritten by subsequent calls to the method.
+ *
+ * @method namespace
+ * @chainable
+ * @param {String} namespace A namespace string, e.g. "wp"
+ * @return {WPRequest} The WPRequest instance (for chaining)
+ */
+WPRequest.prototype.namespace = function( namespace ) {
+	this._namespace = namespace;
+	return this;
+};
+
+/**
+ * Set the version of the request, e.g. to specify that "v2" of the wordpress
+ * API routes should be used. Any previously-set version will be overwritten by
+ * subsequent calls to the method.
+ *
+ * @method version
+ * @chainable
+ * @param {String} version An API version identifier string, e.g. "v2"
+ * @return {WPRequest} The WPRequest instance (for chaining)
+ */
+WPRequest.prototype.version = function( version ) {
+	this._version = version;
+	return this;
+};
 
 /**
  * Set a requst to use authentication, and optionally provide auth credentials

--- a/tests/lib/shared/wp-request.js
+++ b/tests/lib/shared/wp-request.js
@@ -55,6 +55,53 @@ describe( 'WPRequest', function() {
 
 	}); // constructor
 
+	describe( 'namespace', function() {
+
+		it( 'is defined', function() {
+			expect( request ).to.have.property( 'namespace' );
+			expect( request.namespace ).to.be.a( 'function' );
+		});
+
+		it( 'sets a value that is prepended to the path', function() {
+			request.namespace( 'ns' );
+			expect( request._renderPath() ).to.equal( 'ns' );
+		});
+
+		it( 'prefixes any provided template', function() {
+			request._template = 'template';
+			request.namespace( 'ns' );
+			expect( request._renderPath() ).to.equal( 'ns/template' );
+		});
+
+	});
+
+	describe( 'version', function() {
+
+		it( 'is defined', function() {
+			expect( request ).to.have.property( 'version' );
+			expect( request.version ).to.be.a( 'function' );
+		});
+
+		it( 'sets a value that is prepended to the path', function() {
+			request.version( 'v8' );
+			expect( request._renderPath() ).to.equal( 'v8' );
+		});
+
+		it( 'prefixes the provided template', function()  {
+			request._template = 'template';
+			request.version( 'v8' );
+			expect( request._renderPath() ).to.equal( 'v8/template' );
+		});
+
+		it( 'prefixes any provided namespace', function()  {
+			request._template = 'template';
+			request.namespace( 'ns' );
+			request.version( 'v8' );
+			expect( request._renderPath() ).to.equal( 'ns/v8/template' );
+		});
+
+	});
+
 	describe( 'auth', function() {
 
 		it( 'is defined', function() {


### PR DESCRIPTION
This sets the groundwork for being able to maintain an API base-relative client instance, while still permitting the handlers for native WP-API endpoints to retrieve the correct data, by giving them a mechanism by which to find their data at e.g. `endpoint/wp/v2/posts` instead of `endpoint/posts`.