### PR TITLE
Use wp/v2/ endpoints for all native types

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -83,6 +83,9 @@ function MediaRequest( options ) {
 	 * @default [ 'head', 'get', 'post' ]
 	 */
 	this._supportedMethods = [ 'head', 'get', 'post' ];
+
+	// Default all .media() requests to assume a query against the WP API v2 endpoints
+	this.namespace( 'wp' ).version( 'v2' );
 }
 
 inherit( MediaRequest, CollectionRequest );

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -83,6 +83,9 @@ function PagesRequest( options ) {
 	 * @default [ 'head', 'get', 'post' ]
 	 */
 	this._supportedMethods = [ 'head', 'get', 'post' ];
+
+	// Default all .pages() requests to assume a query against the WP API v2 endpoints
+	this.namespace( 'wp' ).version( 'v2' );
 }
 
 inherit( PagesRequest, CollectionRequest );

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -83,6 +83,9 @@ function PostsRequest( options ) {
 	 * @default [ 'head', 'get', 'post' ]
 	 */
 	this._supportedMethods = [ 'head', 'get', 'post' ];
+
+	// Default all .posts() requests to assume a query against the WP API v2 endpoints
+	this.namespace( 'wp' ).version( 'v2' );
 }
 
 inherit( PostsRequest, CollectionRequest );

--- a/lib/taxonomies.js
+++ b/lib/taxonomies.js
@@ -74,6 +74,9 @@ function TaxonomiesRequest( options ) {
 	 * @default [ 'head', 'get' ]
 	 */
 	this._supportedMethods = [ 'head', 'get' ];
+
+	// Default all .taxonomies() requests to assume a query against the WP API v2 endpoints
+	this.namespace( 'wp' ).version( 'v2' );
 }
 
 // TaxonomiesRequest extends CollectionRequest

--- a/lib/types.js
+++ b/lib/types.js
@@ -74,6 +74,9 @@ function TypesRequest( options ) {
 	 * @default [ 'head', 'get' ]
 	 */
 	this._supportedMethods = [ 'head', 'get' ];
+
+	// Default all .types() requests to assume a query against the WP API v2 endpoints
+	this.namespace( 'wp' ).version( 'v2' );
 }
 
 // TypesRequest extends CollectionRequest

--- a/lib/users.js
+++ b/lib/users.js
@@ -76,6 +76,9 @@ function UsersRequest( options ) {
 	 */
 	this._supportedMethods = [ 'head', 'get', 'post' ];
 
+	// Default all .users() requests to assume a query against the WP API v2 endpoints
+	this.namespace( 'wp' ).version( 'v2' );
+
 	// Force authentication on all users requests
 	return this.auth();
 }

--- a/tests/lib/media.js
+++ b/tests/lib/media.js
@@ -109,17 +109,17 @@ describe( 'wp.media', function() {
 
 		it( 'should create the URL for the media collection', function() {
 			var uri = media._renderURI();
-			expect( uri ).to.equal( 'http://some-site.com/wp-json/media' );
+			expect( uri ).to.equal( 'http://some-site.com/wp-json/wp/v2/media' );
 		});
 
 		it( 'can paginate the media collection responses', function() {
 			var uri = media.page( 4 )._renderURI();
-			expect( uri ).to.equal( 'http://some-site.com/wp-json/media?page=4' );
+			expect( uri ).to.equal( 'http://some-site.com/wp-json/wp/v2/media?page=4' );
 		});
 
 		it( 'should create the URL for a specific media object', function() {
 			var uri = media.id( 1492 )._renderURI();
-			expect( uri ).to.equal( 'http://some-site.com/wp-json/media/1492' );
+			expect( uri ).to.equal( 'http://some-site.com/wp-json/wp/v2/media/1492' );
 		});
 
 	});

--- a/tests/lib/pages.js
+++ b/tests/lib/pages.js
@@ -90,21 +90,21 @@ describe( 'wp.pages', function() {
 			var newPages = new PagesRequest();
 			newPages._options.endpoint = 'endpoint/url/';
 			var path = newPages.id( 3 )._renderURI();
-			expect( path ).to.equal( 'endpoint/url/pages/3' );
+			expect( path ).to.equal( 'endpoint/url/wp/v2/pages/3' );
 		});
 
 		describe( 'page collections', function() {
 
 			it( 'should create the URL for retrieving all pages', function() {
 				var path = pages._renderURI();
-				expect( path ).to.equal( '/wp-json/pages' );
+				expect( path ).to.equal( '/wp-json/wp/v2/pages' );
 			});
 
 			it( 'should provide filtering methods', function() {
 				expect( pages ).to.have.property( 'filter' );
 				expect( pages.filter ).to.be.a( 'function' );
 				var path = pages.filter( 'name', 'some-slug' )._renderURI();
-				expect( path ).to.equal( '/wp-json/pages?filter%5Bname%5D=some-slug' );
+				expect( path ).to.equal( '/wp-json/wp/v2/pages?filter%5Bname%5D=some-slug' );
 			});
 
 		});
@@ -113,12 +113,13 @@ describe( 'wp.pages', function() {
 
 			it( 'should create the URL for retrieving a specific post', function() {
 				var path = pages.id( 1337 )._renderURI();
-				expect( path ).to.equal( '/wp-json/pages/1337' );
+				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337' );
 			});
 
 			it( 'should create the URL for retrieving a post by path', function() {
 				var path = pages.path( 'nested/page' )._renderURI();
-				expect( path ).to.equal( '/wp-json/pages?filter%5Bpagename%5D=nested%2Fpage' );
+				expect( path ).to
+					.equal( '/wp-json/wp/v2/pages?filter%5Bpagename%5D=nested%2Fpage' );
 			});
 
 			it( 'should update the supported methods when setting ID', function() {
@@ -139,7 +140,7 @@ describe( 'wp.pages', function() {
 
 			it( 'should create the URL for a page\'s comments collection', function() {
 				var path = pages.id( 1337 ).comments()._renderURI();
-				expect( path ).to.equal( '/wp-json/pages/1337/comments' );
+				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/comments' );
 			});
 
 			it( 'should set the correct supported methods for the comments endpoint', function() {
@@ -150,7 +151,7 @@ describe( 'wp.pages', function() {
 
 			it( 'should create the URL for retrieving a specific comment', function() {
 				var path = pages.id( 1337 ).comments().comment( 9001 )._renderURI();
-				expect( path ).to.equal( '/wp-json/pages/1337/comments/9001' );
+				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/comments/9001' );
 			});
 
 			it( 'should set the correct supported methods for the comment endpoint', function() {
@@ -161,14 +162,14 @@ describe( 'wp.pages', function() {
 
 			it( 'should force action "comments" when calling .comment()', function() {
 				var path = pages.id( 1337 ).comment( 9002 )._renderURI();
-				expect( path ).to.equal( '/wp-json/pages/1337/comments/9002' );
+				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/comments/9002' );
 			});
 
 		});
 
 		it( 'should create the URL for retrieving the revisions for a specific post', function() {
 			var path = pages.id( 1337 ).revisions()._renderURI();
-			expect( path ).to.equal( '/wp-json/pages/1337/revisions' );
+			expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/revisions' );
 		});
 
 		it( 'should force authentication when querying pages/id/revisions', function() {

--- a/tests/lib/posts.js
+++ b/tests/lib/posts.js
@@ -168,7 +168,7 @@ describe( 'wp.posts', function() {
 			expect( posts._params.type ).to.deep.equal( 'some_cpt' );
 
 			var uri = posts._renderURI();
-			expect( uri ).to.equal( '/wp-json/posts?type=some_cpt' );
+			expect( uri ).to.equal( '/wp-json/wp/v2/posts?type=some_cpt' );
 		});
 
 		it( 'merges the values provided in successive calls to type', function() {
@@ -184,7 +184,7 @@ describe( 'wp.posts', function() {
 				'page'
 			]);
 
-			var uri = '/wp-json/posts?type%5B0%5D=cpt1&type%5B1%5D=cpt2&type%5B2%5D=page';
+			var uri = '/wp-json/wp/v2/posts?type%5B0%5D=cpt1&type%5B1%5D=cpt2&type%5B2%5D=page';
 			expect( posts._renderURI() ).to.equal( uri );
 		});
 
@@ -203,12 +203,12 @@ describe( 'wp.posts', function() {
 
 		it( 'should create the URL for retrieving all posts', function() {
 			var path = posts._renderURI();
-			expect( path ).to.equal( '/wp-json/posts' );
+			expect( path ).to.equal( '/wp-json/wp/v2/posts' );
 		});
 
 		it( 'should create the URL for retrieving a specific post', function() {
 			var path = posts.id( 1337 )._renderURI();
-			expect( path ).to.equal( '/wp-json/posts/1337' );
+			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337' );
 		});
 
 		it( 'throws an error if an invalid ID is specified', function() {
@@ -225,32 +225,32 @@ describe( 'wp.posts', function() {
 
 		it( 'should create the URL for retrieving all meta for a specific post', function() {
 			var path = posts.id( 1337 ).meta()._renderURI();
-			expect( path ).to.equal( '/wp-json/posts/1337/meta' );
+			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/meta' );
 		});
 
 		it( 'should create the URL for retrieving a specific comment', function() {
 			var path = posts.id( 1337 ).meta( 2001 )._renderURI();
-			expect( path ).to.equal( '/wp-json/posts/1337/meta/2001' );
+			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/meta/2001' );
 		});
 
 		it( 'should create the URL for retrieving all comments for a specific post', function() {
 			var path = posts.id( 1337 ).comments()._renderURI();
-			expect( path ).to.equal( '/wp-json/posts/1337/comments' );
+			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/comments' );
 		});
 
 		it( 'should create the URL for retrieving a specific comment', function() {
 			var path = posts.id( 1337 ).comments().comment( 9001 )._renderURI();
-			expect( path ).to.equal( '/wp-json/posts/1337/comments/9001' );
+			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/comments/9001' );
 		});
 
 		it( 'should force the "comments" action when comment() is called', function() {
 			var path = posts.id( 2501 ).comment( 9 )._renderURI();
-			expect( path ).to.equal( '/wp-json/posts/2501/comments/9' );
+			expect( path ).to.equal( '/wp-json/wp/v2/posts/2501/comments/9' );
 		});
 
 		it( 'should create the URL for retrieving the revisions for a specific post', function() {
 			var path = posts.id( 1337 ).revisions()._renderURI();
-			expect( path ).to.equal( '/wp-json/posts/1337/revisions' );
+			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/revisions' );
 		});
 
 		it( 'should force authentication when querying posts/id/revisions', function() {
@@ -264,7 +264,7 @@ describe( 'wp.posts', function() {
 			var newPosts = new PostsRequest();
 			newPosts._options.endpoint = 'endpoint/url/';
 			var path = newPosts.id( 3 )._renderURI();
-			expect( path ).to.equal( 'endpoint/url/posts/3' );
+			expect( path ).to.equal( 'endpoint/url/wp/v2/posts/3' );
 		});
 
 	});

--- a/tests/lib/shared/wp-request.js
+++ b/tests/lib/shared/wp-request.js
@@ -73,6 +73,14 @@ describe( 'WPRequest', function() {
 			expect( request._renderPath() ).to.equal( 'ns/template' );
 		});
 
+		it( 'can be removed (to support the legacy api v1)', function() {
+			request._template = 'template';
+			request.namespace( '' );
+			expect( request._renderPath() ).to.equal( 'template' );
+			request.namespace();
+			expect( request._renderPath() ).to.equal( 'template' );
+		});
+
 	});
 
 	describe( 'version', function() {
@@ -98,6 +106,14 @@ describe( 'WPRequest', function() {
 			request.namespace( 'ns' );
 			request.version( 'v8' );
 			expect( request._renderPath() ).to.equal( 'ns/v8/template' );
+		});
+
+		it( 'can be removed (to support the legacy api v1)', function() {
+			request._template = 'template';
+			request.version( '' );
+			expect( request._renderPath() ).to.equal( 'template' );
+			request.version();
+			expect( request._renderPath() ).to.equal( 'template' );
 		});
 
 	});

--- a/tests/lib/shared/wp-request.js
+++ b/tests/lib/shared/wp-request.js
@@ -73,11 +73,15 @@ describe( 'WPRequest', function() {
 			expect( request._renderPath() ).to.equal( 'ns/template' );
 		});
 
-		it( 'can be removed (to support the legacy api v1)', function() {
+		it( 'can be removed (to use the legacy api v1) with an empty string', function() {
 			request._template = 'template';
-			request.namespace( '' );
+			request.namespace( 'wp' ).namespace( '' );
 			expect( request._renderPath() ).to.equal( 'template' );
-			request.namespace();
+		});
+
+		it( 'can be removed (to use the legacy api v1) by omitting arguments', function() {
+			request._template = 'template';
+			request.namespace( 'wp' ).namespace();
 			expect( request._renderPath() ).to.equal( 'template' );
 		});
 
@@ -108,11 +112,15 @@ describe( 'WPRequest', function() {
 			expect( request._renderPath() ).to.equal( 'ns/v8/template' );
 		});
 
-		it( 'can be removed (to support the legacy api v1)', function() {
+		it( 'can be removed (to use the legacy api v1) with an empty string', function() {
 			request._template = 'template';
-			request.version( '' );
+			request.version( 'v2' ).version( '' );
 			expect( request._renderPath() ).to.equal( 'template' );
-			request.version();
+		});
+
+		it( 'can be removed (to use the legacy api v1) by omitting arguments', function() {
+			request._template = 'template';
+			request.version( 'v2' ).version();
 			expect( request._renderPath() ).to.equal( 'template' );
 		});
 

--- a/tests/lib/shared/wp-request.js
+++ b/tests/lib/shared/wp-request.js
@@ -515,11 +515,11 @@ describe( 'WPRequest', function() {
 						'x-wp-totalpages': 4,
 						'x-wp-total': 7,
 						link: [
-							'</wp-json/posts?page=1>; rel="prev",',
-							'</wp-json/posts?page=2>; rel="next",',
-							'<http://site.com/wp-json/posts/1024>; rel="item";',
+							'</wp-json/wp/v2/posts?page=1>; rel="prev",',
+							'</wp-json/wp/v2/posts?page=2>; rel="next",',
+							'<http://site.com/wp-json/wp/v2/posts/1024>; rel="item";',
 							'title="Article Title",',
-							'<http://site.com/wp-json/posts/994>; rel="item";',
+							'<http://site.com/wp-json/wp/v2/posts/994>; rel="item";',
 							'title="Another Article"'
 						].join( ' ' )
 					},
@@ -529,10 +529,10 @@ describe( 'WPRequest', function() {
 					expect( parsedResult ).to.have.property( '_paging' );
 					expect( parsedResult._paging ).to.have.property( 'links' );
 					expect( parsedResult._paging.links ).to.have.property( 'prev' );
-					var expectedPrevLink = '/wp-json/posts?page=1';
+					var expectedPrevLink = '/wp-json/wp/v2/posts?page=1';
 					expect( parsedResult._paging.links.prev ).to.equal( expectedPrevLink );
 					expect( parsedResult._paging.links ).to.have.property( 'next' );
-					var expectedNextLink = '/wp-json/posts?page=2';
+					var expectedNextLink = '/wp-json/wp/v2/posts?page=2';
 					expect( parsedResult._paging.links.next ).to.equal( expectedNextLink );
 				});
 			});
@@ -544,7 +544,7 @@ describe( 'WPRequest', function() {
 						headers: {
 							'x-wp-totalpages': 4,
 							'x-wp-total': 7,
-							link: '</wp-json/posts?page=3>; rel="next"'
+							link: '</wp-json/wp/v2/posts?page=3>; rel="next"'
 						},
 						body: {}
 					};
@@ -556,22 +556,22 @@ describe( 'WPRequest', function() {
 						expect( parsedResult._paging ).to.have.property( 'next' );
 						expect( parsedResult._paging.next ).to.be.an.instanceof( SandboxedRequest );
 						expect( parsedResult._paging.next._options.endpoint ).to.equal(
-							'http://site.com/wp-json/posts?page=3'
+							'http://site.com/wp-json/wp/v2/posts?page=3'
 						);
 					});
 				});
 
 				it( 'is generated correctly for requests to explicit endpoints', function() {
 					// Testing full URLs as endpoints validates that _paging.next.then works
-					wpRequest._options.endpoint = 'http://site.com/wp-json/posts?page=3';
-					mockAgent._response.headers.link = '</wp-json/posts?page=4>; rel="next"';
+					wpRequest._options.endpoint = 'http://site.com/wp-json/wp/v2/posts?page=3';
+					mockAgent._response.headers.link = '</wp-json/wp/v2/posts?page=4>; rel="next"';
 
 					return wpRequest.then(function( parsedResult ) {
 						expect( parsedResult ).to.have.property( '_paging' );
 						expect( parsedResult._paging ).to.have.property( 'next' );
 						expect( parsedResult._paging.next ).to.be.an.instanceof( SandboxedRequest );
 						expect( parsedResult._paging.next._options.endpoint ).to.equal(
-							'http://site.com/wp-json/posts?page=4'
+							'http://site.com/wp-json/wp/v2/posts?page=4'
 						);
 					});
 				});
@@ -585,7 +585,7 @@ describe( 'WPRequest', function() {
 						headers: {
 							'x-wp-totalpages': 4,
 							'x-wp-total': 7,
-							link: '</wp-json/posts?page=2>; rel="prev"'
+							link: '</wp-json/wp/v2/posts?page=2>; rel="prev"'
 						},
 						body: {}
 					};
@@ -597,22 +597,22 @@ describe( 'WPRequest', function() {
 						expect( parsedResult._paging ).to.have.property( 'prev' );
 						expect( parsedResult._paging.prev ).to.be.an.instanceof( SandboxedRequest );
 						expect( parsedResult._paging.prev._options.endpoint ).to.equal(
-							'http://site.com/wp-json/posts?page=2'
+							'http://site.com/wp-json/wp/v2/posts?page=2'
 						);
 					});
 				});
 
 				it( 'is generated correctly for requests to explicit endpoints', function() {
 					// Testing full URLs as endpoints validates that _paging.prev.then works
-					wpRequest._options.endpoint = 'http://site.com/wp-json/posts?page=2';
-					mockAgent._response.headers.link = '</wp-json/posts?page=1>; rel="prev"';
+					wpRequest._options.endpoint = 'http://site.com/wp-json/wp/v2/posts?page=2';
+					mockAgent._response.headers.link = '</wp-json/wp/v2/posts?page=1>; rel="prev"';
 
 					return wpRequest.then(function( parsedResult ) {
 						expect( parsedResult ).to.have.property( '_paging' );
 						expect( parsedResult._paging ).to.have.property( 'prev' );
 						expect( parsedResult._paging.prev ).to.be.an.instanceof( SandboxedRequest );
 						expect( parsedResult._paging.prev._options.endpoint ).to.equal(
-							'http://site.com/wp-json/posts?page=1'
+							'http://site.com/wp-json/wp/v2/posts?page=1'
 						);
 					});
 				});

--- a/tests/lib/taxonomies.js
+++ b/tests/lib/taxonomies.js
@@ -83,17 +83,17 @@ describe( 'wp.taxonomies', function() {
 
 		it( 'should create the URL for retrieving all taxonomies', function() {
 			var url = taxonomies._renderURI();
-			expect( url ).to.equal( '/wp-json/taxonomies' );
+			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies' );
 		});
 
 		it( 'should create the URL for retrieving a specific taxonomy', function() {
 			var url = taxonomies.taxonomy( 'my-tax' )._renderURI();
-			expect( url ).to.equal( '/wp-json/taxonomies/my-tax' );
+			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies/my-tax' );
 		});
 
 		it( 'should create the URL for retrieving all terms for a specific taxonomy', function() {
 			var url = taxonomies.taxonomy( 'my-tax' ).terms()._renderURI();
-			expect( url ).to.equal( '/wp-json/taxonomies/my-tax/terms' );
+			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies/my-tax/terms' );
 		});
 
 		it( 'should error if any _path.action other than "terms" is set', function() {
@@ -105,7 +105,7 @@ describe( 'wp.taxonomies', function() {
 
 		it( 'should create the URL for retrieving a specific taxonomy term', function() {
 			var url = taxonomies.taxonomy( 'my-tax' ).terms().term( 1337 )._renderURI();
-			expect( url ).to.equal( '/wp-json/taxonomies/my-tax/terms/1337' );
+			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies/my-tax/terms/1337' );
 		});
 
 	});

--- a/tests/lib/types.js
+++ b/tests/lib/types.js
@@ -74,12 +74,12 @@ describe( 'wp.types', function() {
 
 		it( 'should create the URL for retrieving all types', function() {
 			var url = types._renderURI();
-			expect( url ).to.equal( '/wp-json/posts/types' );
+			expect( url ).to.equal( '/wp-json/wp/v2/posts/types' );
 		});
 
 		it( 'should create the URL for retrieving a specific term', function() {
 			var url = types.type( 'some_type' )._renderURI();
-			expect( url ).to.equal( '/wp-json/posts/types/some_type' );
+			expect( url ).to.equal( '/wp-json/wp/v2/posts/types/some_type' );
 		});
 
 	});

--- a/tests/lib/users.js
+++ b/tests/lib/users.js
@@ -110,20 +110,20 @@ describe( 'wp.users', function() {
 
 		it( 'should create the URL for retrieving all users', function() {
 			var url = users._renderURI();
-			expect( url ).to.equal( '/wp-json/users' );
+			expect( url ).to.equal( '/wp-json/wp/v2/users' );
 		});
 
 		it( 'should create the URL for retrieving the current user', function() {
 			var url = users.me()._renderURI();
 			var _supportedMethods = users._supportedMethods.sort().join( '|' );
-			expect( url ).to.equal( '/wp-json/users/me' );
+			expect( url ).to.equal( '/wp-json/wp/v2/users/me' );
 			expect( _supportedMethods ).to.equal( 'get|head' );
 		});
 
 		it( 'should create the URL for retrieving a specific user by ID', function() {
 			var url = users.id( 1337 )._renderURI();
 			var _supportedMethods = users._supportedMethods.sort().join( '|' );
-			expect( url ).to.equal( '/wp-json/users/1337' );
+			expect( url ).to.equal( '/wp-json/wp/v2/users/1337' );
 			expect( _supportedMethods ).to.equal( 'delete|get|head|post|put' );
 		});
 

--- a/tests/wp.js
+++ b/tests/wp.js
@@ -223,20 +223,21 @@ describe( 'wp', function() {
 		it( 'defines a .categories() shortcut for the category taxonomy terms', function() {
 			var categories = site.categories();
 			expect( categories instanceof TaxonomiesRequest ).to.be.true;
-			expect( categories._renderURI() ).to.equal( 'endpoint/url/taxonomies/category/terms' );
+			expect( categories._renderURI() ).to
+				.equal( 'endpoint/url/wp/v2/taxonomies/category/terms' );
 		});
 
 		it( 'defines a .tags() shortcut for the tag taxonomy terms', function() {
 			var tags = site.tags();
 			expect( tags instanceof TaxonomiesRequest ).to.be.true;
-			expect( tags._renderURI() ).to.equal( 'endpoint/url/taxonomies/post_tag/terms' );
+			expect( tags._renderURI() ).to.equal( 'endpoint/url/wp/v2/taxonomies/post_tag/terms' );
 		});
 
 		it( 'defines a generic .taxonomy() handler for arbitrary taxonomy objects', function() {
 			var taxRequest = site.taxonomy( 'my_custom_tax' );
 			expect( taxRequest instanceof TaxonomiesRequest ).to.be.true;
 			var uri = taxRequest._renderURI();
-			expect( uri ).to.equal( 'endpoint/url/taxonomies/my_custom_tax' );
+			expect( uri ).to.equal( 'endpoint/url/wp/v2/taxonomies/my_custom_tax' );
 		});
 
 	});


### PR DESCRIPTION
This continues the addition of native support for the WP API v2 series, by making all WordPress native type request methods (such as `.posts()` automatically set the "wp/v2" namespace and API version key in their request URL string.

To request one of these resources, we can now continue to specify the api client's endpoint as the json root, e.g. `yoursite.com/wp-json`, and the posts, pages, etc methods will automatically set the correct path to hit API v2 resources.

@tommedema and others who have experimented with using this alongside the API v2, please comment to let me know if this approach both makes sense, and works for you!