### PR TITLE
Add code coverage reporting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,8 @@ module.exports = function( grunt ) {
 			}
 		},
 
+		// Simplemocha is only used for the watch task:
+		// `npm test` runs mocha via its CLI
 		simplemocha: {
 			tests: {
 				src: files.tests,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "lint": "grunt jshint jscs",
     "mocha": "grunt test",
     "watch": "grunt watch",
-    "test": "grunt"
+    "pretest": "npm run lint",
+    "test": "istanbul cover _mocha -- tests --recursive --reporter=nyan"
   },
   "engines": {
     "node": ">= 0.10.0"
@@ -53,6 +54,7 @@
     "grunt-jscs": "^1.2.0",
     "grunt-newer": "^0.7.0",
     "grunt-simple-mocha": "^0.4.0",
+    "istanbul": "^0.3.22",
     "jscs-stylish": "^0.3.0",
     "jshint-stylish": "^0.2.0",
     "load-grunt-tasks": "^0.6.0",

--- a/tests/lib/shared/collection-request.js
+++ b/tests/lib/shared/collection-request.js
@@ -333,6 +333,20 @@ describe( 'CollectionRequest', function() {
 				});
 			});
 
+			it( 'de-dupes the taxonomy list', function() {
+				request.taxonomy( 'post_tag', [
+					'disclosure',
+					'alunageorge',
+					'disclosure',
+					'lorde',
+					'lorde',
+					'clean-bandit'
+				]);
+				expect( request._taxonomyFilters ).to.deep.equal({
+					tag: [ 'alunageorge', 'clean-bandit', 'disclosure', 'lorde' ]
+				});
+			});
+
 		});
 
 		describe( 'category()', function() {
@@ -501,6 +515,19 @@ describe( 'CollectionRequest', function() {
 			it( 'should be chainable, and replace values', function() {
 				expect( request.month( 2 ).month( 'September' ) ).to.equal( request );
 				expect( request._filters.monthnum ).to.equal( 9 );
+			});
+
+			it( 'should not set anything if an invalid string is provided', function() {
+				request.month( 'The oldest in the family is moving with authority' );
+				expect( request._filters.monthnum ).to.be.undefined;
+			});
+
+			it( 'should not set anything if a non-number is provided', function() {
+				request.month({
+					wake: 'me up',
+					when: 'September ends'
+				});
+				expect( request._filters.monthnum ).to.be.undefined;
 			});
 
 		});


### PR DESCRIPTION
This adds code-coverage reporting with [Istanbul](https://gotwarlost.github.io/istanbul/).

After running `npm test`, a coverage report will be printed:

![image](https://cloud.githubusercontent.com/assets/442115/10323105/fbb178c4-6c4e-11e5-9251-af537ec73929.png)

A line-by-line report can be accessed by loading the generated `coverage/lcov-report` HTML report directory in a web browser.
