### PR TITLE
Add integration tests for post creation & updating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
+script: "npm run test:ci"
 node_js:
+  - "stable"
+  - "4.1"
+  - "4.0"
   - "0.12"
-  - "0.11"
-  - "0.10"
+  - "iojs"
 # Opt-in to travis container infrastructure
 sudo: false

--- a/README.md
+++ b/README.md
@@ -60,6 +60,55 @@ wp.posts().then(function( data ) {
 });
 ```
 
+### Creating Posts
+
+To create posts, use the `.post()` method on a query to POST a data object to the server (POST is the HTTP "verb" equivalent for "create"):
+
+```js
+// You must authenticate to be able to POST (create) a post
+var wp = new WP({
+    endpoint: 'http://your-site.com/wp-json',
+    // This assumes you are using basic auth, as described further below
+    username: 'someusername',
+    password: 'password'
+});
+wp.posts().post({
+    // "title" and "content" are the only required properties
+    title: 'Your Post Title',
+    content: 'Your post content',
+    // Post will be created as a draft by default if a specific "status"
+    // is not specified
+    status: 'publish'
+}).then(function( response ) {
+    // "response" will hold all properties of your newly-created post,
+    // including the unique `id` the post was assigned on creation
+    console.log( response.id );
+})
+```
+
+### Updating Posts
+
+To create posts, use the `.put()` method on a single-item query to PUT a data object to the server (PUT is the HTTP "verb" equivalent for "update"):
+
+```js
+// You must authenticate to be able to PUT (update) a post
+var wp = new WP({
+    endpoint: 'http://your-site.com/wp-json',
+    // This assumes you are using basic auth, as described further below
+    username: 'someusername',
+    password: 'password'
+});
+// .id() must be used to specify the post we are updating
+wp.posts().id( 2501 ).post({
+    // Update the title
+    title: 'A Better Title',
+    // Set the post live (assuming it was "draft" before)
+    status: 'publish'
+}).then(function( response ) {
+    console.log( response );
+})
+```
+
 ### Requesting Different Resources
 
 A WP instance object provides the following basic request methods:

--- a/lib/shared/wp-request.js
+++ b/lib/shared/wp-request.js
@@ -406,17 +406,30 @@ WPRequest.prototype.version = function( version ) {
  *
  * @method auth
  * @chainable
- * @param {String} [username] A username string for basic authentication
- * @param {String} [password] A user password string for basic authentication
+ * @param {String|Object} [usrOrObj] A username string for basic authentication,
+ *                                   or an object with 'username' and 'password'
+ *                                   string properties
+ * @param {String}        [password] A user password string for basic authentication
+ *                                   (ignored if usrOrObj is an object)
  * @return {WPRequest} The WPRequest instance (for chaining)
  */
-WPRequest.prototype.auth = function( username, password ) {
-	if ( username && typeof username === 'string' ) {
-		this._options.username = username;
-	}
+WPRequest.prototype.auth = function( usrOrObj, password ) {
+	if ( typeof usrOrObj === 'object' ) {
+		if ( typeof usrOrObj.username === 'string' ) {
+			this._options.username = usrOrObj.username;
+		}
 
-	if ( password && typeof password === 'string' ) {
-		this._options.password = password;
+		if ( typeof usrOrObj.password === 'string' ) {
+			this._options.password = usrOrObj.password;
+		}
+	} else {
+		if ( typeof usrOrObj === 'string' ) {
+			this._options.username = usrOrObj;
+		}
+
+		if ( typeof password === 'string' ) {
+			this._options.password = password;
+		}
 	}
 
 	// Set the "auth" options flag that will force authentication on this request

--- a/lib/shared/wp-request.js
+++ b/lib/shared/wp-request.js
@@ -480,13 +480,18 @@ WPRequest.prototype.put = function( data, callback ) {
 /**
  * @method delete
  * @async
+ * @param {Object} [data] Data to send along with the DELETE request
  * @param {Function} [callback] A callback to invoke with the results of the DELETE request
  * @return {Promise} A promise to the results of the HTTP request
  */
-WPRequest.prototype.delete = function( callback ) {
+WPRequest.prototype.delete = function( data, callback ) {
+	if ( ! callback && typeof data === 'function' ) {
+		callback = data;
+		data = null;
+	}
 	this._checkMethodSupport( 'delete' );
 	var url = this._renderURI();
-	var request = this._auth( agent.del( url ), true );
+	var request = this._auth( agent.del( url ), true ).send( data );
 
 	return invokeAndPromisify( request, callback, returnBody.bind( this ) );
 };

--- a/lib/shared/wp-request.js
+++ b/lib/shared/wp-request.js
@@ -432,8 +432,6 @@ WPRequest.prototype.auth = function( username, password ) {
  * @method get
  * @async
  * @param {Function} [callback] A callback to invoke with the results of the GET request
- * @param {Error|Object} callback.err Any errors encountered during the request
- * @param {Object} callback.result The body of the server response
  * @return {Promise} A promise to the results of the HTTP request
  */
 WPRequest.prototype.get = function( callback ) {
@@ -450,8 +448,6 @@ WPRequest.prototype.get = function( callback ) {
  * @async
  * @param {Object} data The data for the POST request
  * @param {Function} [callback] A callback to invoke with the results of the POST request
- * @param {Error|Object} callback.err Any errors encountered during the request
- * @param {Object} callback.result The body of the server response
  * @return {Promise} A promise to the results of the HTTP request
  */
 WPRequest.prototype.post = function( data, callback ) {
@@ -469,8 +465,6 @@ WPRequest.prototype.post = function( data, callback ) {
  * @async
  * @param {Object} data The data for the PUT request
  * @param {Function} [callback] A callback to invoke with the results of the PUT request
- * @param {Error|Object} callback.err Any errors encountered during the request
- * @param {Object} callback.result The body of the server response
  * @return {Promise} A promise to the results of the HTTP request
  */
 WPRequest.prototype.put = function( data, callback ) {
@@ -487,8 +481,6 @@ WPRequest.prototype.put = function( data, callback ) {
  * @method delete
  * @async
  * @param {Function} [callback] A callback to invoke with the results of the DELETE request
- * @param {Error|Object} callback.err Any errors encountered during the request
- * @param {Object} callback.result The body of the server response
  * @return {Promise} A promise to the results of the HTTP request
  */
 WPRequest.prototype.delete = function( callback ) {
@@ -503,8 +495,6 @@ WPRequest.prototype.delete = function( callback ) {
  * @method head
  * @async
  * @param {Function} [callback] A callback to invoke with the results of the HEAD request
- * @param {Error|Object} callback.err Any errors encountered during the request
- * @param {Object} callback.result The headers from the server response
  * @return {Promise} A promise to the header results of the HTTP request
  */
 WPRequest.prototype.head = function( callback ) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "wordpress"
   ],
   "scripts": {
-    "prepublish": "grunt",
     "docs": "grunt yuidoc",
     "lint": "grunt jshint jscs",
     "mocha": "_mocha tests --recursive --reporter=nyan",
@@ -31,8 +30,9 @@
     "test:all": "_mocha tests --recursive --reporter=nyan",
     "test:unit": "_mocha tests/unit --recursive --reporter=nyan",
     "test:integration": "_mocha tests/integration --recursive --reporter=nyan",
+    "test:ci": "npm run lint && istanbul cover _mocha -- tests/unit --recursive --reporter=list",
     "pretest": "npm run lint",
-    "test": "istanbul cover _mocha -- tests/unit --recursive --reporter=nyan"
+    "test": "istanbul cover _mocha -- tests --recursive --reporter=nyan"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -1,6 +1,8 @@
 'use strict';
 var chai = require( 'chai' );
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( 'success' ) is
+// Variable to use as our "success token" in promise assertions
+var SUCCESS = 'success';
+// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
 // used to ensure that the assertions running within the promise chains are
 // actually run.
 chai.use( require( 'chai-as-promised' ) );
@@ -70,17 +72,17 @@ describe( 'integration: posts()', function() {
 		var prom = wp.posts().get().then(function( posts ) {
 			expect( posts ).to.be.an( 'array' );
 			expect( posts.length ).to.equal( 10 );
-			return 'success';
+			return SUCCESS;
 		});
-		return expect( prom ).to.eventually.equal( 'success' );
+		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
 	it( 'fetches the 10 most recent posts by default', function() {
 		var prom = wp.posts().get().then(function( posts ) {
 			expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page1 );
-			return 'success';
+			return SUCCESS;
 		});
-		return expect( prom ).to.eventually.equal( 'success' );
+		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
 	describe( 'paging properties', function() {
@@ -89,27 +91,27 @@ describe( 'integration: posts()', function() {
 			var prom = wp.posts().get().then(function( posts ) {
 				expect( posts ).to.have.property( '_paging' );
 				expect( posts._paging ).to.be.an( 'object' );
-				return 'success';
+				return SUCCESS;
 			});
-			return expect( prom ).to.eventually.equal( 'success' );
+			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
 		it( 'include the total number of posts', function() {
 			var prom = wp.posts().get().then(function( posts ) {
 				expect( posts._paging ).to.have.property( 'total' );
 				expect( posts._paging.total ).to.equal( '38' );
-				return 'success';
+				return SUCCESS;
 			});
-			return expect( prom ).to.eventually.equal( 'success' );
+			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
 		it( 'include the total number of pages available', function() {
 			var prom = wp.posts().get().then(function( posts ) {
 				expect( posts._paging ).to.have.property( 'totalPages' );
 				expect( posts._paging.totalPages ).to.equal( '4' );
-				return 'success';
+				return SUCCESS;
 			});
-			return expect( prom ).to.eventually.equal( 'success' );
+			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
 		it( 'provides a bound WPRequest for the next page as .next', function() {
@@ -123,10 +125,10 @@ describe( 'integration: posts()', function() {
 				return wp.posts().page( posts._paging.totalPages ).get().then(function( posts ) {
 					expect( posts._paging ).not.to.have.property( 'next' );
 					expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page4 );
-					return 'success';
+					return SUCCESS;
 				});
 			});
-			return expect( prom ).to.eventually.equal( 'success' );
+			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
 		it( 'allows access to the next page of results via .next', function() {
@@ -135,10 +137,10 @@ describe( 'integration: posts()', function() {
 					expect( posts ).to.be.an( 'array' );
 					expect( posts.length ).to.equal( 9 );
 					expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page2 );
-					return 'success';
+					return SUCCESS;
 				});
 			});
-			return expect( prom ).to.eventually.equal( 'success' );
+			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
 		it( 'provides a bound WPRequest for the previous page as .prev', function() {
@@ -150,10 +152,10 @@ describe( 'integration: posts()', function() {
 					expect( posts._paging.prev ).to.be.an.instanceOf( WPRequest );
 					expect( posts._paging.prev._options.endpoint ).to
 						.equal( 'http://wpapi.loc/wp-json/wp/v2/posts?page=1' );
-					return 'success';
+					return SUCCESS;
 				});
 			});
-			return expect( prom ).to.eventually.equal( 'success' );
+			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
 		it( 'allows access to the previous page of results via .prev', function() {
@@ -163,10 +165,10 @@ describe( 'integration: posts()', function() {
 					expect( posts ).to.be.an( 'array' );
 					expect( posts.length ).to.equal( 10 );
 					expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page1 );
-					return 'success';
+					return SUCCESS;
 				});
 			});
-			return expect( prom ).to.eventually.equal( 'success' );
+			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
 	});
@@ -185,9 +187,9 @@ describe( 'integration: posts()', function() {
 						'',
 						'Edge Case: Many Tags'
 					]);
-					return 'success';
+					return SUCCESS;
 				});
-				return expect( prom ).to.eventually.equal( 'success' );
+				return expect( prom ).to.eventually.equal( SUCCESS );
 			});
 
 			it( 'can be used to return only posts with all provided tags', function() {
@@ -201,9 +203,9 @@ describe( 'integration: posts()', function() {
 						'Template: Featured Image (Horizontal)',
 						'Edge Case: Many Tags'
 					]);
-					return 'success';
+					return SUCCESS;
 				});
-				return expect( prom ).to.eventually.equal( 'success' );
+				return expect( prom ).to.eventually.equal( SUCCESS );
 			});
 
 		});
@@ -221,9 +223,9 @@ describe( 'integration: posts()', function() {
 						'Markup: Title With Markup',
 						'Edge Case: Many Categories'
 					]);
-					return 'success';
+					return SUCCESS;
 				});
-				return expect( prom ).to.eventually.equal( 'success' );
+				return expect( prom ).to.eventually.equal( SUCCESS );
 			});
 
 			// Pending until we confirm whether querying by multiple category_name is permitted
@@ -236,9 +238,9 @@ describe( 'integration: posts()', function() {
 					expect( getTitles( posts ) ).to.deep.equal([
 						'Edge Case: Many Categories'
 					]);
-					return 'success';
+					return SUCCESS;
 				});
-				return expect( prom ).to.eventually.equal( 'success' );
+				return expect( prom ).to.eventually.equal( SUCCESS );
 			});
 
 		});

--- a/tests/unit/lib/shared/wp-request.js
+++ b/tests/unit/lib/shared/wp-request.js
@@ -140,7 +140,7 @@ describe( 'WPRequest', function() {
 			expect( request._options.auth ).to.be.true;
 		});
 
-		it( 'sets the username and password options, if provided', function() {
+		it( 'sets the username and password when provided as strings', function() {
 			expect( request._options ).not.to.have.property( 'username' );
 			expect( request._options ).not.to.have.property( 'password' );
 			request.auth( 'user', 'pass' );
@@ -148,6 +148,23 @@ describe( 'WPRequest', function() {
 			expect( request._options ).to.have.property( 'password' );
 			expect( request._options.username ).to.equal( 'user' );
 			expect( request._options.password ).to.equal( 'pass' );
+			expect( request._options ).to.have.property( 'auth' );
+			expect( request._options.auth ).to.be.true;
+		});
+
+		it( 'sets the username and password when provided in an object', function() {
+			expect( request._options ).not.to.have.property( 'username' );
+			expect( request._options ).not.to.have.property( 'password' );
+			request.auth({
+				username: 'user',
+				password: 'pass'
+			});
+			expect( request._options ).to.have.property( 'username' );
+			expect( request._options ).to.have.property( 'password' );
+			expect( request._options.username ).to.equal( 'user' );
+			expect( request._options.password ).to.equal( 'pass' );
+			expect( request._options ).to.have.property( 'auth' );
+			expect( request._options.auth ).to.be.true;
 		});
 
 	}); // auth

--- a/tests/unit/lib/shared/wp-request.js
+++ b/tests/unit/lib/shared/wp-request.js
@@ -427,6 +427,26 @@ describe( 'WPRequest', function() {
 				});
 			});
 
+			it( 'should pass through a provided data object', function() {
+				sinon.spy( mockAgent, 'del' );
+				sinon.spy( mockAgent, 'auth' );
+				sinon.spy( mockAgent, 'send' );
+				sinon.stub( mockAgent, 'end' );
+
+				wpRequest._options.username = 'user';
+				wpRequest._options.password = 'pass';
+				var options = { force: true };
+
+				wpRequest.delete( options );
+
+				expect( mockAgent.del ).to.have.been.calledOnce;
+				expect( mockAgent.del ).to.have.been.calledWith( 'url/' );
+				expect( mockAgent.auth ).to.have.been.calledOnce;
+				expect( mockAgent.auth ).to.have.been.calledWith( 'user', 'pass' );
+				expect( mockAgent.send ).to.have.been.calledOnce;
+				expect( mockAgent.send ).to.have.been.calledWith( options );
+			});
+
 			it( 'should return a Promise to the body of the request data', function() {
 				mockAgent._response = { body: 'resp', headers: {} };
 				var promise = wpRequest.delete();


### PR DESCRIPTION
The fact that 403's are returned for some requests and 401's for others is a result of https://core.trac.wordpress.org/ticket/35527

This adds documentation and an integration test around a full post create-update-delete cycle