### PR TITLE
Test on Node.js v0.12.x, v4.x, and v5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 script: "npm run test:ci"
 node_js:
-  - "stable"
-  - "4.1"
-  - "4.0"
+  - "5"
+  - "4"
   - "0.12"
-  - "iojs"
 # Opt-in to travis container infrastructure
 sudo: false


### PR DESCRIPTION
Based on commit message https://github.com/kadamwhite/wordpress-rest-api/commit/79be86917ffd83929275174f92a3351a608742e3 _"Travis should test recent stable node versions, as well as iojs"_ I've updated the NodeJS test matrix:

• iojs is for all intensive purposes deprecated, it was merged back into the v4 branch of NodeJS https://iojs.org/en/

• The latest LTS (Long Term Support) version of NodeJS is v4.2.4, using the `4` alias will always use the latest 4.x.x branch

• The latest "stable" is the 5.x branch which is currently v5.4.1, again using `5` will always test the latest v5.x.x branch. (Note Also the NVM alias `stable` is deprecated, https://github.com/creationix/nvm#usage)