### PR TITLE
set _paging property on result of all paged requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Additional querying methods provided, by endpoint:
     - `wp.posts()`: get a collection of posts (default query)
     - `wp.posts().id( n )`: get the post with ID *n*
     - `wp.posts().id( n ).comments()`: get all comments for post with ID *n*
-    - `wp.posts().id( n ).comment( i )`: get a comment with the ID *i* from post with ID *n* 
+    - `wp.posts().id( n ).comment( i )`: get a comment with the ID *i* from post with ID *n*
     - `wp.posts().id( n ).revisions()`: get a collection of revisions for the post with ID *n*
     - `wp.posts().type( type_name )`: get posts of custom type *type_name*
     - *There is currently no support for querying post meta values*
@@ -137,7 +137,7 @@ Additional querying methods provided, by endpoint:
     - `wp.pages().id( n )`: get the page with numeric ID *n*
     - `wp.pages().path( 'path/str' )`: get the page with the root-relative URL path `path/str`
     - `wp.pages().id( n ).comments()`: get all comments for page with ID *n*
-    - `wp.pages().id( n ).comment( i )`: get a comment with the ID *i* from page with ID *n* 
+    - `wp.pages().id( n ).comment( i )`: get a comment with the ID *i* from page with ID *n*
     - `wp.pages().id( n ).revisions()`: get a collection of revisions for the page with ID *n*
 * **taxonomies**
     - `wp.taxonomies()`: retrieve all registered taxonomies
@@ -286,8 +286,6 @@ To work around these restrictions, paginated collection responses are augmented 
 - `prev`: A WPRequest object pre-bound to the previous page of results
 - `links`: an object containing the parsed `link` HTTP header data
 
-The existence of the `_paging` property can be used as a flag to conditionally show or hide your paging UI, if necessary, as it will not be present for single-page or single-item responses.
-
 You can use the `next` and `prev` properties to traverse an entire collection, should you so choose. For example, this snippet will recursively request the next page and concatenate it with existing results, in order to build up an array of every post on your site:
 ```javascript
 getAll( request ) {
@@ -369,8 +367,8 @@ First localize your scripts with an object with root-url and nonce in your theme
 function my_enqueue_scripts() {
     wp_enqueue_script( 'app', get_template_directory_uri() . '/assets/dist/bundle.js', array(), false, true );
     wp_localize_script( 'app', 'WP_API_Settings', array(
-        'endpoint' => esc_url_raw( get_json_url() ), 
-        'nonce' => wp_create_nonce( 'wp_json' ) ) 
+        'endpoint' => esc_url_raw( get_json_url() ),
+        'nonce' => wp_create_nonce( 'wp_json' ) )
     );
 }
 add_action( 'wp_enqueue_scripts', 'my_enqueue_scripts' );
@@ -381,7 +379,7 @@ And then use this nonce when initializing the library:
 ```javascript
 var WP = require( 'wordpress-rest-api' );
 var wp = new WP({
-    endpoint: window.WP_API_Settings.endpoint, 
+    endpoint: window.WP_API_Settings.endpoint,
     nonce: window.WP_API_Settings.nonce
 });
 ```

--- a/lib/shared/wp-request.js
+++ b/lib/shared/wp-request.js
@@ -222,20 +222,20 @@ function mergeUrl( endpoint, linkPath ) {
  *                   pagination metadata
  */
 function paginateResponse( result, endpoint ) {
-	if ( ! result.headers || ! result.headers.link ) {
+	if ( ! result.headers || ! result.headers[ 'x-wp-totalpages' ] ) {
 		// No headers: return as-is
 		return result;
 	}
 
 	var totalPages = result.headers[ 'x-wp-totalpages' ];
 
-	if ( ! totalPages || totalPages === '0' || totalPages === '1' ) {
+	if ( ! totalPages || totalPages === '0' ) {
 		// No paging: return as-is
 		return result;
 	}
 
 	// Decode the link header object
-	var links = parseLinkHeader( result.headers.link );
+	var links = result.headers.link ? parseLinkHeader( result.headers.link ) : {};
 
 	// Store pagination data from response headers on the response collection
 	result.body._paging = {

--- a/tests/unit/lib/shared/wp-request.js
+++ b/tests/unit/lib/shared/wp-request.js
@@ -529,17 +529,22 @@ describe( 'WPRequest', function() {
 				});
 			});
 
-			it( 'passes data through unchanged if header has no link property', function() {
+			it( 'sets pagination properties if headers include paging counts without links', function() {
 				mockAgent._response = {
 					headers: {
-						'x-wp-totalpages': '0',
-						'x-wp-total': '0'
+						'x-wp-totalpages': 1,
+						'x-wp-total': 5
 					},
-					body: 'some object'
+					body: {}
 				};
 				return wpRequest.then(function( parsedResult ) {
-					expect( parsedResult ).to.equal( 'some object' );
-					expect( parsedResult ).not.to.have.property( '_paging' );
+					expect( parsedResult ).to.have.property( '_paging' );
+					expect( parsedResult._paging ).not.to.have.property( 'next' );
+					expect( parsedResult._paging ).not.to.have.property( 'prev' );
+					expect( parsedResult._paging ).to.have.property( 'total' );
+					expect( parsedResult._paging.total ).to.equal( 5 );
+					expect( parsedResult._paging ).to.have.property( 'totalPages' );
+					expect( parsedResult._paging.totalPages ).to.equal( 1 );
 				});
 			});
 


### PR DESCRIPTION
Keep the `_paging` property (with totalPages, total) on any response to a paged request, even if results fit within a single page.

See discussion at: https://github.com/jasonphillips/wordpress-rest-api/commit/353ecbd1d0877a469943719467ac677bbb31d399
