### PR TITLE
Add forpost method to tax collections

### DIFF
--- a/lib/taxonomies.js
+++ b/lib/taxonomies.js
@@ -148,4 +148,18 @@ TaxonomiesRequest.prototype.parent = function( parentId ) {
 	return this;
 };
 
+/**
+ * Specify the post for which to retrieve terms
+ *
+ * @method forPost
+ * @chainable
+ * @param {String|Number} post The ID of the post for which to retrieve terms
+ * @return {TaxonomiesRequest} The TaxonomiesRequest instance (for chaining)
+ */
+TaxonomiesRequest.prototype.forPost = function( postId ) {
+	this.param( 'post', postId );
+
+	return this;
+};
+
 module.exports = TaxonomiesRequest;

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -280,7 +280,7 @@ describe( 'integration: posts()', function() {
 		}).catch(function( err ) {
 			expect( err ).to.be.an( 'object' );
 			expect( err ).to.have.property( 'status' );
-			expect( err.status ).to.equal( 403 );
+			expect( err.status ).to.equal( 401 );
 			return SUCCESS;
 		});
 		return expect( prom ).to.eventually.equal( SUCCESS );
@@ -297,7 +297,7 @@ describe( 'integration: posts()', function() {
 		}).catch(function( err ) {
 			expect( err ).to.be.an( 'object' );
 			expect( err ).to.have.property( 'status' );
-			expect( err.status ).to.equal( 403 );
+			expect( err.status ).to.equal( 401 );
 			return SUCCESS;
 		});
 		return expect( prom ).to.eventually.equal( SUCCESS );

--- a/tests/unit/lib/taxonomies.js
+++ b/tests/unit/lib/taxonomies.js
@@ -85,6 +85,11 @@ describe( 'wp.taxonomies', function() {
 			expect( url ).to.equal( '/wp-json/wp/v2/categories?parent=42' );
 		});
 
+		it( 'should permit specifying the parent for a collection of terms', function() {
+			var url = taxonomies.collection( 'categories' ).forPost( 1234 )._renderURI();
+			expect( url ).to.equal( '/wp-json/wp/v2/categories?post=1234' );
+		});
+
 	});
 
 });


### PR DESCRIPTION
This adds support for fetching the terms for a given post, per the changes introduced to WP-API in v2 beta 11.

`.post()` is not a viable chaining method because that maps to sending a POST request: `forPost()` is a more readable, declarative way to specify the post for which to retrieve terms.