### PR TITLE
Alter .slug() collection filter method to use new ?slug= parameter

### DIFF
--- a/lib/shared/collection-request.js
+++ b/lib/shared/collection-request.js
@@ -292,27 +292,29 @@ CollectionRequest.prototype.author = function( author ) {
 };
 
 /**
- * Query a collection of posts for a post with a specific slug.
+ * Query a collection for members with a specific slug.
+ *
+ * @method slug
+ * @chainable
+ * @param {String} slug A post slug (slug), e.g. "hello-world"
+ * @return {CollectionRequest} The CollectionRequest instance (for chaining)
+ */
+CollectionRequest.prototype.slug = function( slug ) {
+	return this.param( 'slug', slug );
+};
+
+/**
+ * Alias for .slug()
  *
  * @method name
+ * @alias slug
  * @chainable
  * @param {String} slug A post name (slug), e.g. "hello-world"
  * @return {CollectionRequest} The CollectionRequest instance (for chaining)
  */
 CollectionRequest.prototype.name = function( slug ) {
-	return this.filter( 'name', slug );
+	return this.slug( slug );
 };
-
-/**
- * Alias for `.name()`.
- *
- * @method slug
- * @alias name
- * @chainable
- * @param {String} slug A post slug, e.g. "hello-world"
- * @return {CollectionRequest} The CollectionRequest instance (for chaining)
- */
-CollectionRequest.prototype.slug = CollectionRequest.prototype.name;
 
 /**
  * Query for posts published in a given year.

--- a/tests/unit/lib/shared/collection-request.js
+++ b/tests/unit/lib/shared/collection-request.js
@@ -382,34 +382,30 @@ describe( 'CollectionRequest', function() {
 
 		});
 
-		describe( 'name()', function() {
-
-			it( 'should set the "name" filter property on the request object', function() {
-				request.name( 'greatest-post-in-the-world' );
-				expect( request._filters.name ).to.equal( 'greatest-post-in-the-world' );
-			});
-
-			it( 'should be chainable, and replace values', function() {
-				expect( request.name( 'post-slug-1' ).name( 'hello-world' ) ).to.equal( request );
-				expect( request._filters.name ).to.equal( 'hello-world' );
-			});
-
-		});
-
 		describe( 'slug()', function() {
 
-			it( 'should be an alias for name()', function() {
-				expect( request.slug ).to.equal( request.name );
-			});
-
-			it( 'should set the "name" filter property on the request object', function() {
+			it( 'should set the "slug" parameter on the request', function() {
 				request.slug( 'greatest-post-in-the-world' );
-				expect( request._filters.name ).to.equal( 'greatest-post-in-the-world' );
+				expect( request._renderURI() ).to.equal( '/?slug=greatest-post-in-the-world' );
 			});
 
 			it( 'should be chainable, and replace values', function() {
 				expect( request.slug( 'post-slug-1' ).slug( 'hello-world' ) ).to.equal( request );
-				expect( request._filters.name ).to.equal( 'hello-world' );
+				expect( request._renderURI() ).to.equal( '/?slug=hello-world' );
+			});
+
+		});
+
+		describe( 'name()', function() {
+
+			it( 'should alias through to set the "slug" parameter on the request', function() {
+				request.name( 'greatest-post-in-the-world' );
+				expect( request._renderURI() ).to.equal( '/?slug=greatest-post-in-the-world' );
+			});
+
+			it( 'should be chainable, and replace values', function() {
+				expect( request.name( 'post-slug-1' ).name( 'hello-world' ) ).to.equal( request );
+				expect( request._renderURI() ).to.equal( '/?slug=hello-world' );
 			});
 
 		});


### PR DESCRIPTION
V2 Beta 11 added support for a slug property (see discussion started in WP-API/WP-API#2065) -- we should use that instead of the `filter[name]` "shim" for WP_Query.

This PR updates the API client to set the `slug` parameter instead of the `name` filter, and makes `name()` call through to `slug()` as opposed to the other way around.