### PR TITLE
Add wp-json to endpoint URL in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The REST API client requires Node.js version 0.10 or above.
 The module is a constructor, so you can create an instance of the API client bound to the endpoint for your WordPress install:
 ```javascript
 var WP = require( 'wordpress-rest-api' );
-var wp = new WP({ endpoint: 'http://src.wordpress-develop.dev' });
+var wp = new WP({ endpoint: 'http://src.wordpress-develop.dev/wp-json' });
 ```
 Once an instance is constructed, you can chain off of it to construct a specific request. (Think of it as a query-builder for WordPress!)
 


### PR DESCRIPTION
As I was setting up a project locally, I was not able to get the example to work, then I figured out I needed to add `wp-json` to the end of the endpoint URL.