### PR TITLE
Improve query parameter generation

### DIFF
--- a/lib/shared/wp-request.js
+++ b/lib/shared/wp-request.js
@@ -226,6 +226,34 @@ function prepareTaxonomies( taxonomyFilters ) {
 	}, {});
 }
 
+/**
+ * Return an object with any properties with undefined, null or empty string
+ * values removed.
+ *
+ * @example
+ *
+ *     populated({
+ *       a: 'a',
+ *       b: '',
+ *       c: null
+ *     }); // { a: 'a' }
+ *
+ * @param  {Object} obj An object of key/value pairs
+ * @return {Object}     That object with all empty values removed
+ */
+function populated( obj ) {
+	if ( ! obj ) {
+		return obj;
+	}
+	return Object.keys( obj ).reduce(function( values, key ) {
+		var val = obj[ key ];
+		if ( ! _.isUndefined( val ) && ! _.isNull( val ) && val !== '' ) {
+			values[ key ] = val;
+		}
+		return values;
+	}, {});
+}
+
 // Pagination-Related Helpers
 // ==========================
 
@@ -334,11 +362,11 @@ function paginateResponse( result, endpoint ) {
  */
 WPRequest.prototype._renderQuery = function() {
 	// Build the full query parameters object
-	var queryParams = extend( {}, this._params );
+	var queryParams = extend( {}, populated( this._params ) );
 
 	// Prepare any taxonomies and merge with other filter values
 	var taxonomies = prepareTaxonomies( this._taxonomyFilters );
-	queryParams.filter = extend( {}, this._filters, taxonomies );
+	queryParams.filter = extend( {}, populated( this._filters ), taxonomies );
 
 	// Parse query parameters object into a query string, sorting the object
 	// properties by alphabetical order (consistent property ordering can make

--- a/tests/unit/lib/shared/collection-request.js
+++ b/tests/unit/lib/shared/collection-request.js
@@ -33,7 +33,6 @@ describe( 'CollectionRequest', function() {
 			expect( request._filters ).to.deep.equal( {} );
 			expect( request._taxonomyFilters ).to.deep.equal( {} );
 			expect( request._params ).to.deep.equal( {} );
-			expect( request._path ).to.deep.equal( {} );
 			expect( request._template ).to.equal( '' );
 		});
 
@@ -338,6 +337,11 @@ describe( 'CollectionRequest', function() {
 		});
 
 		describe( 'search()', function() {
+
+			it( 'should do nothing if no search string is provided', function() {
+				request.search( '' );
+				expect( request._renderQuery() ).to.equal( '' );
+			});
 
 			it( 'should set the "s" filter property on the request object', function() {
 				request.search( 'Some search string' );

--- a/tests/unit/lib/shared/wp-request.js
+++ b/tests/unit/lib/shared/wp-request.js
@@ -33,8 +33,6 @@ describe( 'WPRequest', function() {
 		it( 'should define a _supportedMethods array', function() {
 			var _supportedMethods = request._supportedMethods.sort().join( '|' );
 			expect( _supportedMethods ).to.equal( 'delete|get|head|post|put' );
-			expect( request._path ).to.deep.equal( {} );
-			expect( request._template ).to.equal( '' );
 		});
 
 	});
@@ -135,17 +133,30 @@ describe( 'WPRequest', function() {
 
 		it( 'will set a query parameter value', function() {
 			request.param( 'key', 'value' );
-			expect( request._params ).to.have.property( 'key' );
-			expect( request._params.key ).to.equal( 'value' );
+			expect( request._renderQuery() ).to.equal( '?key=value' );
+		});
+
+		it( 'will unset a query parameter value if called with empty string', function() {
+			request.param( 'key', 'value' );
+			expect( request._renderQuery() ).to.equal( '?key=value' );
+			request.param( 'key', 'value' );
+			request.param( 'key', '' );
+			expect( request._renderQuery() ).to.equal( '' );
+		});
+
+		it( 'will unset a query parameter value if called with null', function() {
+			request.param( 'key', 'value' );
+			expect( request._renderQuery() ).to.equal( '?key=value' );
+			request.param( 'key', 'value' );
+			request.param( 'key', null );
+			expect( request._renderQuery() ).to.equal( '' );
 		});
 
 		it( 'should set the internal _params hash', function() {
 			request.param( 'type', 'some_cpt' );
-			expect( request._params ).to.have.property( 'type' );
-			expect( request._params.type ).to.equal( 'some_cpt' );
+			expect( request._renderQuery() ).to.equal( '?type=some_cpt' );
 			request.param( 'context', 'edit' );
-			expect( request._params ).to.have.property( 'context' );
-			expect( request._params.context ).to.equal( 'edit' );
+			expect( request._renderQuery() ).to.equal( '?context=edit&type=some_cpt' );
 		});
 
 		it( 'should set parameters by passing a hash object', function() {
@@ -153,10 +164,7 @@ describe( 'WPRequest', function() {
 				page: 309,
 				context: 'view'
 			});
-			expect( request._params ).to.have.property( 'page' );
-			expect( request._params.page ).to.equal( 309 );
-			expect( request._params ).to.have.property( 'context' );
-			expect( request._params.context ).to.equal( 'view' );
+			expect( request._renderQuery() ).to.equal( '?context=view&page=309' );
 		});
 
 		it( 'should merge provided values if merge is set to true', function() {
@@ -167,9 +175,9 @@ describe( 'WPRequest', function() {
 
 		it( 'should merge, de-dupe & sort array values', function() {
 			request.param( 'type', [ 'post', 'page', 'post' ] );
-			expect( request._params.type ).to.deep.equal( [ 'page', 'post' ] );
+			expect( request._renderQuery() ).to.equal( '?type%5B%5D=page&type%5B%5D=post' );
 			request.param( 'type', [ 'page', 'cpt_item' ], true );
-			expect( request._params.type ).to.deep.equal( [ 'cpt_item', 'page', 'post' ] );
+			expect( request._renderQuery() ).to.equal( '?type%5B%5D=cpt_item&type%5B%5D=page&type%5B%5D=post' );
 		});
 
 	});


### PR DESCRIPTION
Do not include empty parameters in the generated query string.

Do not inspect `_params` when testing query string generation: instead, inspect the generated URL (which will be a public API eventually). `_params` is an internal implementation detail and should not be part of our tested interface.