### PR TITLE
Remove outdated v1 code

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,25 +225,7 @@ The following methods are shortcuts for filtering the requested collection down 
 
 ### Custom Post Types
 
-In addition to the filters described above, the `posts()` request method provides a chaining method `type()` which can be used to target your query at one or more custom post types:
-```javascript
-// Find items for a specific CPT
-wp.posts().type( 'your_cpt' )...
-
-// Retrieve both your own CPT, and the native "post" type
-wp.posts().type([ 'your_cpt', 'post' ])...
-```
-If you are building an application that relies very heavily on custom types, you may find yourself wanting a convenience method for requesting your own custom type. The method `registerType` can be used to define a convenience method of that sort:
-```javascript
-// Defines a CPT handler `events()` on the current WP instance
-wp.events = wp.registerType( 'event_cpt' );
-```
-`wp.events()`` can now be used to specify requests for that custom post type quickly:
-```javascript
-wp.events().then(function( eventItems ) {
-  // Do something with the returned collection of event objects
-});
-```
+Support for Custom Post Types has been removed temporarily, but will be reinstated soon once the client supports the new custom post handling changes introduced in the new v2 API betas.
 
 ## Embedding data
 

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ A WP instance object provides the following basic request methods:
 * `wp.taxonomies()...`: Generate a request against the `/taxonomies` endpoints
 * `wp.pages()...`: Start a request for the `/pages` endpoints
 * `wp.users()...`: Get resources within the `/users` endpoints
-* `wp.types()...`: Get Post Type collections and objects from the `/posts/types` endpoints
+* `wp.types()...`: Get Post Type collections and objects from the `/types` endpoints
 * `wp.media()...`: Get Media collections and objects from the `/media` endpoints
 
-All of these methods return a customizable request object. The request object can be further refined with chaining methods, and/or sent to the server via `.get()`, `.post()`, `.put()`, `.delete()`, `.head()`, or `.then()`. (Not all endpoints support all methods; for example, you cannot POST or PUT records on `/posts/types`, as these are defined in WordPress plugin or theme code.)
+All of these methods return a customizable request object. The request object can be further refined with chaining methods, and/or sent to the server via `.get()`, `.post()`, `.put()`, `.delete()`, `.head()`, or `.then()`. (Not all endpoints support all methods; for example, you cannot POST or PUT records on `/types`, as these are defined in WordPress plugin or theme code.)
 
 Additional querying methods provided, by endpoint:
 

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -6,7 +6,6 @@
  */
 var CollectionRequest = require( './shared/collection-request' );
 var inherit = require( 'util' ).inherits;
-var _ = require( 'lodash' );
 
 /**
  * PostsRequest extends CollectionRequest to handle the /posts API endpoint
@@ -167,58 +166,6 @@ PostsRequest.prototype.revisions = function() {
 	this._supportedMethods = [ 'head', 'get' ];
 
 	return this.auth();
-};
-
-/**
- * Adds the Year filter into the request to retrieve posts for a given year
- *
- * @method year
- * @chainable
- * @param {Number} year Integer representation of year requested
- * @returns {PostsRequest} The PostsRequest instance (for chaining)
- */
-PostsRequest.prototype.year = function( year ) {
-	return this.filter( 'year', year );
-};
-
-/**
- * Add the monthnum filter into the request to retrieve posts for a given month
- *
- * Filters posts by a given month in either Integer or String Format.
- *
- * @method month
- * @chainable
- * @param {Number|String} month Integer for month or month string ("january")
- * @returns {PostsRequest} The PostsRequest instance (for chaining)
- */
-PostsRequest.prototype.month = function( month ) {
-	if ( _.isString( month ) ) {
-		// Append a arbitrary day and year to the month to parse the string into a Date
-		month = new Date( Date.parse( month + ' 1, 2012' ) );
-		// If month is NaN, then the passed string is not a valid month.
-		if ( isNaN( month ) ) {
-			return this;
-		}
-		// JS Dates are 0 indexed, WP API requires a 1 indexed integer.
-		month = month.getMonth() + 1;
-	}
-	// If month is a Number, add the monthnum filter to the request
-	if ( _.isNumber( month ) ) {
-		return this.filter( 'monthnum', month );
-	}
-	return this;
-};
-
-/**
- * Add the day filter into the request to retrieve posts for a given day
- *
- * @method day
- * @chainable
- * @param {Number} day Integer representation of the day requested
- * @returns {PostsRequest} The PostsRequest instance (for chaining)
- */
-PostsRequest.prototype.day = function( day ) {
-	return this.filter( 'day', day );
 };
 
 module.exports = PostsRequest;

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -109,12 +109,12 @@ PostsRequest.prototype._pathValidators = {
 	id: /^\d+$/,
 
 	/**
-	 * Action must be one of 'meta', 'comments', or 'revisions'
+	 * Action must be one of 'meta' or 'revisions'
 	 *
 	 * @property _pathValidators.action
 	 * @type {RegExp}
 	 */
-	action: /(meta|comments|revisions)/
+	action: /(meta|revisions)/
 };
 
 /**
@@ -156,49 +156,6 @@ PostsRequest.prototype.meta = function( metaId ) {
 };
 
 /**
- * Specify that we are getting the comments for a specific post
- *
- * @method comments
- * @chainable
- * @return {PostsRequest} The PostsRequest instance (for chaining)
- */
-PostsRequest.prototype.comments = function() {
-	this._path.action = 'comments';
-	this._supportedMethods = [ 'head', 'get', 'post' ];
-	return this;
-};
-
-/**
- * Specify a particular comment to retrieve
- * (forces action "comments")
- *
- * @method comment
- * @chainable
- * @param {Number} id The ID of the comment to retrieve
- * @return {PostsRequest}
- */
-PostsRequest.prototype.comment = function( id ) {
-	this._path.action = 'comments';
-	this._path.actionId = parseInt( id, 10 );
-	this._supportedMethods = [ 'head', 'get', 'delete' ];
-
-	return this;
-};
-
-/**
- * Query a collection of posts for posts of a specific type
- *
- * @method type
- * @param {String|Array} type A string or array of strings specifying post types to query
- * @chainable
- * @return {PostsRequest} The PostsRequest instance (for chaining)
- */
-PostsRequest.prototype.type = function( type ) {
-	this.param( 'type', type, true );
-	return this;
-};
-
-/**
  * Specify that we are requesting the revisions for a specific post (forces basic auth)
  *
  * @method revisions
@@ -210,18 +167,6 @@ PostsRequest.prototype.revisions = function() {
 	this._supportedMethods = [ 'head', 'get' ];
 
 	return this.auth();
-};
-
-/**
- * @method statuses
- * @chainable
- * @return {PostsRequest} The PostsRequest instance (for chaining)
- */
-PostsRequest.prototype.statuses = function() {
-	this._path.action = 'statuses';
-	this._supportedMethods = [ 'head', 'get' ];
-
-	return this;
 };
 
 /**

--- a/lib/types.js
+++ b/lib/types.js
@@ -63,9 +63,9 @@ function TypesRequest( options ) {
 	 * @property _template
 	 * @type String
 	 * @private
-	 * @default 'posts/types(/:type)'
+	 * @default 'types(/:type)'
 	 */
-	this._template = 'posts/types(/:type)';
+	this._template = 'types(/:type)';
 
 	/**
 	 * @property _supportedMethods

--- a/tests/unit/lib/posts.js
+++ b/tests/unit/lib/posts.js
@@ -67,7 +67,7 @@ describe( 'wp.posts', function() {
 			var posts = new PostsRequest();
 			expect( posts._pathValidators ).to.deep.equal({
 				id: /^\d+$/,
-				action: /(meta|comments|revisions)/
+				action: /(meta|revisions)/
 			});
 		});
 
@@ -152,42 +152,6 @@ describe( 'wp.posts', function() {
 			expect( _supportedMethods ).to.equal( 'delete|get|head|post|put' );
 		});
 
-		it( 'provides a method to query for comments', function() {
-			expect( posts ).to.have.property( 'comments' );
-			expect( posts.comments ).to.be.a( 'function' );
-			posts.comments();
-			expect( posts._path ).to.have.property( 'action' );
-			expect( posts._path.action ).to.equal( 'comments' );
-		});
-
-		it( 'provides a method to query by type', function() {
-			expect( posts ).to.have.property( 'type' );
-			expect( posts.type ).to.be.a( 'function' );
-			posts.type( 'some_cpt' );
-			expect( posts._params ).to.have.property( 'type' );
-			expect( posts._params.type ).to.deep.equal( 'some_cpt' );
-
-			var uri = posts._renderURI();
-			expect( uri ).to.equal( '/wp-json/wp/v2/posts?type=some_cpt' );
-		});
-
-		it( 'merges the values provided in successive calls to type', function() {
-			posts.type( 'cpt1' ).type( 'cpt2' );
-			expect( posts._params.type ).to.deep.equal([
-				'cpt1',
-				'cpt2'
-			]);
-			posts.type([ 'page' ]);
-			expect( posts._params.type ).to.deep.equal([
-				'cpt1',
-				'cpt2',
-				'page'
-			]);
-
-			var uri = '/wp-json/wp/v2/posts?type%5B%5D=cpt1&type%5B%5D=cpt2&type%5B%5D=page';
-			expect( posts._renderURI() ).to.equal( uri );
-		});
-
 	});
 
 	describe( 'URL Generation', function() {
@@ -228,24 +192,9 @@ describe( 'wp.posts', function() {
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/meta' );
 		});
 
-		it( 'should create the URL for retrieving a specific comment', function() {
+		it( 'should create the URL for retrieving a specific meta item', function() {
 			var path = posts.id( 1337 ).meta( 2001 )._renderURI();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/meta/2001' );
-		});
-
-		it( 'should create the URL for retrieving all comments for a specific post', function() {
-			var path = posts.id( 1337 ).comments()._renderURI();
-			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/comments' );
-		});
-
-		it( 'should create the URL for retrieving a specific comment', function() {
-			var path = posts.id( 1337 ).comments().comment( 9001 )._renderURI();
-			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/comments/9001' );
-		});
-
-		it( 'should force the "comments" action when comment() is called', function() {
-			var path = posts.id( 2501 ).comment( 9 )._renderURI();
-			expect( path ).to.equal( '/wp-json/wp/v2/posts/2501/comments/9' );
 		});
 
 		it( 'should create the URL for retrieving the revisions for a specific post', function() {

--- a/tests/unit/lib/types.js
+++ b/tests/unit/lib/types.js
@@ -37,7 +37,7 @@ describe( 'wp.types', function() {
 			expect( types._filters ).to.deep.equal( {} );
 			expect( types._path ).to.deep.equal( {} );
 			expect( types._params ).to.deep.equal( {} );
-			expect( types._template ).to.equal( 'posts/types(/:type)' );
+			expect( types._template ).to.equal( 'types(/:type)' );
 			expect( _supportedMethods ).to.equal( 'get|head' );
 		});
 
@@ -74,12 +74,12 @@ describe( 'wp.types', function() {
 
 		it( 'should create the URL for retrieving all types', function() {
 			var url = types._renderURI();
-			expect( url ).to.equal( '/wp-json/wp/v2/posts/types' );
+			expect( url ).to.equal( '/wp-json/wp/v2/types' );
 		});
 
 		it( 'should create the URL for retrieving a specific term', function() {
 			var url = types.type( 'some_type' )._renderURI();
-			expect( url ).to.equal( '/wp-json/wp/v2/posts/types/some_type' );
+			expect( url ).to.equal( '/wp-json/wp/v2/types/some_type' );
 		});
 
 	});

--- a/tests/unit/wp.js
+++ b/tests/unit/wp.js
@@ -62,48 +62,6 @@ describe( 'wp', function() {
 
 	});
 
-	describe( '.registerType()', function() {
-
-		it( 'is defined', function() {
-			expect( site ).to.have.property( 'registerType' );
-			expect( site.registerType ).to.be.a( 'function' );
-		});
-
-		it( 'returns a function that creates new PostsRequest instances', function() {
-			var requestMethod = site.registerType( 'some_cpt' );
-			expect( requestMethod ).to.be.a( 'function' );
-			var request = requestMethod();
-			expect( request instanceof PostsRequest ).to.be.true;
-		});
-
-		it( 'binds the returned PostsRequest to the provided post type(s)', function() {
-			var requestMethod = site.registerType( 'cpt_name' );
-			var request = requestMethod();
-			expect( request ).to.have.property( '_params' );
-			expect( request._params ).to.have.property( 'type' );
-			expect( request._params.type ).to.equal( 'cpt_name' );
-
-			// Try with multiple post types
-			var postsAndCPTs = site.registerType([ 'cpt1', 'cpt2', 'posts' ]);
-			request = postsAndCPTs();
-			expect( request._params.type ).to.deep.equal([ 'cpt1', 'cpt2', 'posts' ]);
-		});
-
-		it( 'inherits options from the parent WP instance', function() {
-			var wp = new WP({
-				endpoint: 'http://website.com',
-				custom: 'option value'
-			});
-			var requestMethod = wp.registerType( 'cat_breeds' );
-			var request = requestMethod();
-			expect( request._options ).to.have.property( 'endpoint' );
-			expect( request._options.endpoint ).to.equal( 'http://website.com/' );
-			expect( request._options ).to.have.property( 'custom' );
-			expect( request._options.custom ).to.equal( 'option value' );
-		});
-
-	});
-
 	describe( '.url()', function() {
 
 		it( 'is defined', function() {

--- a/wp.js
+++ b/wp.js
@@ -203,7 +203,7 @@ WP.prototype.tags = function() {
 };
 
 /**
- * Start a request against the `/posts/types` endpoint
+ * Start a request against the `/types` endpoint
  *
  * @method types
  * @param {Object} [options] An options hash for a new TypesRequest

--- a/wp.js
+++ b/wp.js
@@ -229,36 +229,6 @@ WP.prototype.users = function( options ) {
 };
 
 /**
- * Define a method to handle specific custom post types.
- *
- * @example
- * If your site had an events custom type with name `event_cpt`, you could create a convenience
- * method for querying events and store it on the WP instance.
- *
- * Create the WP instance, define the custom endpoint handler, and save it to `wp.events`:
- *
- *     var wp = new WP({ endpoint: 'http://some-website.com/wp-json' });
- *     wp.events = wp.registerType( 'event_cpt' );
- *
- * You can now call `wp.events()` to trigger event post requests
- *
- *     wp.events().get()... // equivalent to wp.posts().type( 'event_cpt' ).get()...
- *
- * `registerType()` just returns a function, so there's no requirement to store it as a property
- * on the WP instance; however, following the above pattern is likely to be the most useful.
- *
- * @method registerType
- * @param {String|Array} type A string or array of post type names
- * @return {Function} A function to create PostsRequests pre-bound to the provided types
- */
-WP.prototype.registerType = function( type ) {
-	var options = extend( {}, this._options );
-	return function() {
-		return new PostsRequest( options ).type( type );
-	};
-};
-
-/**
  * Generate a request against a completely arbitrary endpoint, with no assumptions about
  * or mutation of path, filtering, or query parameters. This request is not restricted to
  * the endpoint specified during WP object instantiation.


### PR DESCRIPTION
- The route for `.types()` is no longer nested under `/posts`
  - The path has been updated; integration tests TODO
- `/comments` and `/statuses` are no longer nested under `/posts/:id`
  - These chaining methods have been removes
- It is no longer possible to access CPT items under `/posts`
  - The `.type` chaining method has been removed
  - The `wp.registerType` method has been removed temporarily pending support for top-level CPT collections
- Date query code was duplicated between PostsRequest & CollectionsRequest
  - The PostsRequest code has been removed