### PR TITLE
Update post deletion integration test for breaking beta 12 changes

### DIFF
--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -349,8 +349,8 @@ describe( 'integration: posts()', function() {
 			return wp.posts().auth( credentials ).id( id ).delete();
 		}).then(function( response ) {
 			expect( response ).to.be.an( 'object' );
-			expect( response ).to.have.property( 'trashed' );
-			expect( response.trashed ).to.equal( true );
+			// DELETE action returns the post object
+			expect( response.id ).to.equal( id );
 			// Query for the post: expect this to fail, since it is trashed and
 			// the unauthenticated user does not have permissions to see it
 			return wp.posts().id( id );
@@ -364,8 +364,15 @@ describe( 'integration: posts()', function() {
 			});
 		}).then(function( response ) {
 			expect( response ).to.be.an( 'object' );
-			expect( response ).to.have.property( 'deleted' );
-			expect( response.deleted ).to.equal( true );
+			// DELETE action returns the post object
+			expect( response.id ).to.equal( id );
+			// Query for the post, with auth: expect this to fail, since it is not
+			// just trashed but now deleted permanently
+			return wp.posts().auth( credentials ).id( id );
+		}).catch(function( error ) {
+			expect( error ).to.be.an( 'object' );
+			expect( error ).to.have.property( 'status' );
+			expect( error.status ).to.equal( 404 );
 			return SUCCESS;
 		});
 		return expect( prom ).to.eventually.equal( SUCCESS );


### PR DESCRIPTION
From https://make.wordpress.org/core/2016/02/09/wp-rest-api-version-2-0-beta-12/ :

> Returns original resource when deleting PTCU. Now that all resources require the `force` param, we don’t need to wrap delete responses with the trash state.

What this means is that we should get the original, unaltered post back in the event that the delete action succeeds, and an error if it does not succeed: the integration test has been modified to rigorously test the side-effects of deletion, by querying for the post to validate that trashing removes it from public results and deletion removes it permanently.