### PR TITLE
Update relation name in embedded category test

### DIFF
--- a/tests/integration/categories.js
+++ b/tests/integration/categories.js
@@ -317,7 +317,7 @@ describe( 'integration: categories()', function() {
 			var prom = wp.posts().perPage( 1 ).embed().get().then(function( posts ) {
 				var post = posts[ 0 ];
 				// Find the categories for this post
-				postCategories = _.findWhere( post._embedded['https://api.w.org/term'], function( terms ) {
+				postCategories = _.findWhere( post._embedded['wp:term'], function( terms ) {
 					if ( terms.length && terms[ 0 ].taxonomy === 'category' ) {
 						return true;
 					}


### PR DESCRIPTION
The key has changed to "wp:term"